### PR TITLE
Mconover/cookie timeout extension

### DIFF
--- a/SublessSignIn/AuthServices/ConfigureAuthorizationServices.cs
+++ b/SublessSignIn/AuthServices/ConfigureAuthorizationServices.cs
@@ -38,10 +38,10 @@ namespace SublessSignIn.AuthServices
                     // Samesite has to be none to support hit tracking
                     options.Cookie.SameSite = SameSiteMode.None;
                     options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                    options.Cookie.MaxAge = TimeSpan.FromDays(14);
                 })
                 .AddOpenIdConnect("oidc", options =>
                 {
-
 
                 });
             services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsHandler>();

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ npm install
 Run back end
 
 ```bash
+cd ../../
 dotnet run --project SublessSignIn/SublessSignIn.csproj
 ```
 


### PR DESCRIPTION
Make our cookie last two weeks, so users don't have to sign in every time they close their browser.