### PR TITLE
Mconover/redirect to survey based on user type

### DIFF
--- a/Subless.UI/sublessui/src/app/services/authorization.service.ts
+++ b/Subless.UI/sublessui/src/app/services/authorization.service.ts
@@ -132,7 +132,7 @@ export class AuthorizationService {
           window.open("https://docs.google.com/forms/d/e/1FAIpQLSe24AZPj1IZ-UAsf_cj5zqLfIci3YTmB7YmLZT1Sr5cTYpM0Q/viewform?usp=pp_url&entry.487372404=Subscriber", "_blank");
         }
 
-        window.location.href = "/bff/logout"
+        window.location.href = "/bff/logout";
       })
     )
   }


### PR DESCRIPTION
Change our unsusbcribe UI workflow so that when a user unsubscribes, they're directed to either a pre-filled survey indicating they're a creator, or indicating they're a user, based on their status in the system.