### PR TITLE
SA-489: On startup, ensure we execute with a single configured log instance

### DIFF
--- a/SublessSignIn/Program.cs
+++ b/SublessSignIn/Program.cs
@@ -17,7 +17,7 @@ namespace SublessSignIn
             Log.Logger = LoggerConfig.GetLogger();
             Log.Logger.Information("Subless bootstrapping...");
 
-            var host = CreateHostBuilder(args).Build();
+            var host = CreateHostBuilder(args, Log.Logger).Build();
             using (var scope = host.Services.CreateScope())
             {
                 var services = scope.ServiceProvider;
@@ -43,10 +43,10 @@ namespace SublessSignIn
             host.Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args)
+        public static IHostBuilder CreateHostBuilder(string[] args, ILogger logger)
         {
             return Host.CreateDefaultBuilder(args)
-                .UseSerilog(LoggerConfig.GetLogger())
+                .UseSerilog(logger)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
Attempting a fix for https://superscribe.myjetbrains.com/youtrack/issue/SA-489, though this change should be harmless in any case.