### PR TITLE
Removing protocol now present in configuration

### DIFF
--- a/Subless.UI.Tests/Tests/test_payout_workflow.py
+++ b/Subless.UI.Tests/Tests/test_payout_workflow.py
@@ -114,6 +114,6 @@ def test_queued_payout_emails(web_driver, subless_activated_creator_user, paying
     patron_receipt = receive_email(inbox_id=patron_mailbox.id)
     assert "Your subless receipt" in patron_receipt.subject
     assert "TestUser" in patron_receipt.body
-    assert f"{Keys.test_client_uri}".replace("https://", "") in patron_receipt.body
+    assert f"{Keys.test_client_uri}".replace("https://", "").replace("http://", "") in patron_receipt.body
     assert "$3.57" in patron_receipt.body
     assert "$0.89" in patron_receipt.body


### PR DESCRIPTION
When we moved everything to configuration to allow local test runs, we had to handle cases with and without protocol